### PR TITLE
Export Target fixes for better transitive properties

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -92,6 +92,7 @@ ENDIF()
 
 PROJECT(osgQt)
 
+INCLUDE(GNUInstallDirs)
 FIND_PACKAGE(OpenSceneGraph 3.6.0 REQUIRED osgDB osgGA osgUtil osgText osgViewer osgWidget)
 SET(OPENSCENEGRAPH_SOVERSION 145)
 

--- a/osgQOpenGLConfig.cmake.in
+++ b/osgQOpenGLConfig.cmake.in
@@ -1,2 +1,24 @@
+if(TARGET osg-qt::osgQOpenGL)
+    set(_OSGQOPENGL_ALREADY_DEFINED ON)
+endif()
+
 include(CMakeFindDependencyMacro)
-include("${CMAKE_CURRENT_LIST_DIR}/osg-qtTargets.cmake") 
+
+if(NOT TARGET Qt5::OpenGL)
+    find_dependency(Qt5 COMPONENTS Gui OpenGL REQUIRED)
+endif()
+# Instead of checking OPENSCENEGRAPH_LIBRARIES, check osgViewer and osgUtil specifically
+if(NOT DEFINED OSGUTIL_LIBRARIES OR NOT DEFINED OSGVIEWER_LIBRARIES OR NOT DEFINED OPENSCENEGRAPH_INCLUDE_DIRS)
+    find_dependency(OpenSceneGraph COMPONENTS osgUtil osgViewer REQUIRED)
+endif()
+
+include("${CMAKE_CURRENT_LIST_DIR}/osg-qtTargets.cmake")
+
+if(NOT _OSGQOPENGL_ALREADY_DEFINED)
+    # Replace the interface link libraries with those found by OSG, to allow this to be more easily relocatable.
+    # Without this, absolute paths to OSG are stored in the target, making the output library non-relocatable
+    # to other machines unless they have OSG in the exact same location.
+    set_target_properties(osg-qt::osgQOpenGL PROPERTIES INTERFACE_LINK_LIBRARIES "Qt5::Widgets;Qt5::OpenGL")
+    target_link_libraries(osg-qt::osgQOpenGL INTERFACE ${OPENSCENEGRAPH_LIBRARIES})
+    target_include_directories(osg-qt::osgQOpenGL INTERFACE ${OPENSCENEGRAPH_INCLUDE_DIRS})
+endif()

--- a/src/osgQOpenGL/CMakeLists.txt
+++ b/src/osgQOpenGL/CMakeLists.txt
@@ -50,6 +50,7 @@ IF ( Qt5Widgets_FOUND )
 
     SETUP_LIBRARY(${LIB_NAME})
 
+    target_include_directories(${LIB_NAME} PUBLIC $<INSTALL_INTERFACE:include>)
     generate_export_header(${LIB_NAME} EXPORT_FILE_NAME "Export")
 
 ENDIF()


### PR DESCRIPTION
Minor improvements to your PR https://github.com/openscenegraph/osgQt/pull/63

* Include directory now set on library target for `INSTALL_INTERFACE`. This makes it so that when linking to the target, you get the install directory added transitively correctly.
* Now using `find_dependency` in your new .in file, to search for Qt5 and OSG if they don't already exist. Otherwise targets might not be found properly unless the parent project finds them first with the right components.
* Fixed transitivity of link libraries and include directories for OSG. The `_OSGQOPENGL_ALREADY_DEFINED` block prevents an issue if the same project uses `find_package()` for osgQt more than once in the source tree. This all is needed for OSG and not Qt, because Qt CMake `find_package` defines proper package names (e.g. `Qt5::OpenGL`) whereas the OpenSceneGraph CMake package only defines variables. This all helps with correct transitivity when doing a make install, then sharing to another computer, to avoid absolute paths being baked into the link library name.
* Added `GNUInstallDirs` usage. Without this on Linux your new `install(TARGETS` will copy the lib files to `lib/` instead of `lib64/`. There may be other ways to solve this but this seemed most standard. Tested on Windows MSVC and Linux gcc.

Although I see the comments on your PR 63, I found this useful and thought I would expand on it based on how we expect to use osgQt.